### PR TITLE
Fixes #5: Exception when a user typed incorrect AWS region name

### DIFF
--- a/sshcld/plugins/aws.py
+++ b/sshcld/plugins/aws.py
@@ -90,6 +90,10 @@ def parse_instances(instances=None):
         print(error)  # error message is not shown without print
         raise AwsApiError(error) from error
 
+    except botocore.exceptions.EndpointConnectionError as error:
+        print(error)  # error message is not shown without print
+        raise AwsApiError(error) from error
+
     except botocore.exceptions.ClientError as error:
         try:
             error_message = error.response['Error']['Message']


### PR DESCRIPTION
Fix for issue #5

This exception should be handled properly now.