### PR TITLE
Fixes #4: Exception when AWS SSO session has expired

### DIFF
--- a/sshcld/plugins/aws.py
+++ b/sshcld/plugins/aws.py
@@ -86,11 +86,8 @@ def parse_instances(instances=None):
                     }
                 )
 
-    except botocore.exceptions.NoCredentialsError as error:
-        print(error)  # error message is not shown without print
-        raise AwsApiError(error) from error
-
-    except botocore.exceptions.EndpointConnectionError as error:
+    except (botocore.exceptions.NoCredentialsError, botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.UnauthorizedSSOTokenError) as error:
         print(error)  # error message is not shown without print
         raise AwsApiError(error) from error
 


### PR DESCRIPTION
Fix for issue #4 

I don't have any SSO account at the moment to test, but I hope this exception will be handled as expected now.